### PR TITLE
Update next and prev requirements

### DIFF
--- a/topsort-catalog-service.yaml
+++ b/topsort-catalog-service.yaml
@@ -245,11 +245,11 @@ components:
       type: object
       properties:
         next:
-          description: Token to be passed in the next call to this request to receive the next page
+          description: Token to be passed in the next call to this request to receive the next page. It must not contain spaces.
           type: string
           example: asTpl1k746
         prev:
-          description: Token to be passed in the next call to this request to receive the previous page
+          description: Token to be passed in the next call to this request to receive the previous page. It must not contain spaces.
           type: string
           example: yIhohZwFbx
 


### PR DESCRIPTION
API clients get weird when you pass query params with spaces in them, and that can cause compatibility problems.
For example `this is a string` will converted to `this+is+a+string`