### PR TITLE
chore: add models section

### DIFF
--- a/topsort-catalog-service.yml
+++ b/topsort-catalog-service.yml
@@ -26,50 +26,38 @@ tags:
   - name: Models
     x-displayName: All Models
     description: |
+      ## Brand
+      <SchemaDefinition schemaRef="#/components/schemas/Brand" />
+
+      ## Category
+      <SchemaDefinition schemaRef="#/components/schemas/Category" />
+
       ## GetProductsByID Request
       <SchemaDefinition schemaRef="#/components/schemas/GetProductsByIDRequest" />
 
       ## GetProductsByID Response
       <SchemaDefinition schemaRef="#/components/schemas/GetProductsByIDResponse" />
 
-      ## Paginated Response
-      <SchemaDefinition schemaRef="#/components/schemas/PaginatedResponse" />
-
-      ## Product
-      <SchemaDefinition schemaRef="#/components/schemas/Product" />
-
-      ## Products Response
-      <SchemaDefinition schemaRef="#/components/schemas/ProductsResponse" />
-
-      ## Paginated Products Response
-      <SchemaDefinition schemaRef="#/components/schemas/PaginatedProductsResponse" />
-
-      ## Category
-      <SchemaDefinition schemaRef="#/components/schemas/Category" />
-
-      ## Categories Response
-      <SchemaDefinition schemaRef="#/components/schemas/CategoriesResponse" />
+      ## Paginated Brands Response
+      <SchemaDefinition schemaRef="#/components/schemas/PaginatedBrandsResponse" />
 
       ## Paginated Categories Response
       <SchemaDefinition schemaRef="#/components/schemas/PaginatedCategoriesResponse" />
 
-      ## Vendor
-      <SchemaDefinition schemaRef="#/components/schemas/Vendor" />
+      ## Paginated Products Response
+      <SchemaDefinition schemaRef="#/components/schemas/PaginatedProductsResponse" />
 
-      ## Vendors Response
-      <SchemaDefinition schemaRef="#/components/schemas/VendorsResponse" />
+      ## Paginated Response
+      <SchemaDefinition schemaRef="#/components/schemas/PaginatedResponse" />
 
       ## Paginated Vendors Response
       <SchemaDefinition schemaRef="#/components/schemas/PaginatedVendorsResponse" />
 
-      ## Brand
-      <SchemaDefinition schemaRef="#/components/schemas/Brand" />
+      ## Product
+      <SchemaDefinition schemaRef="#/components/schemas/Product" />
 
-      ## Brands Response
-      <SchemaDefinition schemaRef="#/components/schemas/BrandsResponse" />
-
-      ## Paginated Brands Response
-      <SchemaDefinition schemaRef="#/components/schemas/PaginatedBrandsResponse" />
+      ## Vendor
+      <SchemaDefinition schemaRef="#/components/schemas/Vendor" />
 
 security:
   - BearerAuth: []

--- a/topsort-catalog-service.yml
+++ b/topsort-catalog-service.yml
@@ -23,6 +23,53 @@ servers:
 tags:
   - name: Catalog
     description: Integration for Marketplaces' catalog queries.
+  - name: Models
+    x-displayName: All Models
+    description: |
+      ## GetProductsByID Request
+      <SchemaDefinition schemaRef="#/components/schemas/GetProductsByIDRequest" />
+
+      ## GetProductsByID Response
+      <SchemaDefinition schemaRef="#/components/schemas/GetProductsByIDResponse" />
+
+      ## Paginated Response
+      <SchemaDefinition schemaRef="#/components/schemas/PaginatedResponse" />
+
+      ## Product
+      <SchemaDefinition schemaRef="#/components/schemas/Product" />
+
+      ## Products Response
+      <SchemaDefinition schemaRef="#/components/schemas/ProductsResponse" />
+
+      ## Paginated Products Response
+      <SchemaDefinition schemaRef="#/components/schemas/PaginatedProductsResponse" />
+
+      ## Category
+      <SchemaDefinition schemaRef="#/components/schemas/Category" />
+
+      ## Categories Response
+      <SchemaDefinition schemaRef="#/components/schemas/CategoriesResponse" />
+
+      ## Paginated Categories Response
+      <SchemaDefinition schemaRef="#/components/schemas/PaginatedCategoriesResponse" />
+
+      ## Vendor
+      <SchemaDefinition schemaRef="#/components/schemas/Vendor" />
+
+      ## Vendors Response
+      <SchemaDefinition schemaRef="#/components/schemas/VendorsResponse" />
+
+      ## Paginated Vendors Response
+      <SchemaDefinition schemaRef="#/components/schemas/PaginatedVendorsResponse" />
+
+      ## Brand
+      <SchemaDefinition schemaRef="#/components/schemas/Brand" />
+
+      ## Brands Response
+      <SchemaDefinition schemaRef="#/components/schemas/BrandsResponse" />
+
+      ## Paginated Brands Response
+      <SchemaDefinition schemaRef="#/components/schemas/PaginatedBrandsResponse" />
 
 security:
   - BearerAuth: []
@@ -149,7 +196,7 @@ paths:
       summary: Retrieves brands
       description: >
         This endpoint is optional. It is used to allow advanced use cases for Banner Ads. Talk to
-        your Account Manager to understand whehter you need to implement this endpoint.
+        your Account Manager to understand whether you need to implement this endpoint.
       operationId: getBrands
       parameters:
         - in: query

--- a/topsort-endpoints.yml
+++ b/topsort-endpoints.yml
@@ -23,6 +23,74 @@ tags:
     description: An auction determines which products should be promoted based on the vendors' bids
   - name: Events
     description: Significant consumer interactions on the e-commerce site.
+  - name: Models
+    x-displayName: All Models
+    description: |
+      ## Auction Request (Full Definition)
+      <SchemaDefinition schemaRef="#/components/schemas/AuctionRequest" />
+
+      ## Auction Request (Sponsored Listings)
+      <SchemaDefinition schemaRef="#/components/schemas/AuctionRequestSponsoredListings" />
+
+      ## Auction Request (General Banners)
+      <SchemaDefinition schemaRef="#/components/schemas/AuctionRequestGeneralBanners" />
+
+      ## Auction Request (Homepage Standalone Banners)
+      <SchemaDefinition schemaRef="#/components/schemas/AuctionRequestHomepageStandaloneBanners" />
+
+      ## Listings Slots
+      <SchemaDefinition schemaRef="#/components/schemas/ListingsSlots" />
+
+      ## Banners Slots
+      <SchemaDefinition schemaRef="#/components/schemas/BannersSlots" />
+
+      ## Product
+      <SchemaDefinition schemaRef="#/components/schemas/Product" />
+
+      ## Vendor
+      <SchemaDefinition schemaRef="#/components/schemas/Vendor" />
+
+      ## Session
+      <SchemaDefinition schemaRef="#/components/schemas/Session" />
+
+      ## Banner Options
+      <SchemaDefinition schemaRef="#/components/schemas/BannerOptions" />
+
+      ## Auction
+      <SchemaDefinition schemaRef="#/components/schemas/Auction" />
+
+      ## Winner
+      <SchemaDefinition schemaRef="#/components/schemas/Winner" />
+
+      ## Event
+      <SchemaDefinition schemaRef="#/components/schemas/Event" />
+
+      ## Impression Event
+      <SchemaDefinition schemaRef="#/components/schemas/ImpressionEvent" />
+
+      ## Click Event
+      <SchemaDefinition schemaRef="#/components/schemas/ClickEvent" />
+
+      ## Purchase Event
+      <SchemaDefinition schemaRef="#/components/schemas/PurchaseEvent" />
+
+      ## Placement
+      <SchemaDefinition schemaRef="#/components/schemas/Placement" />
+
+      ## Impression
+      <SchemaDefinition schemaRef="#/components/schemas/Impression" />
+
+      ## Purchase Item
+      <SchemaDefinition schemaRef="#/components/schemas/PurchaseItem" />
+
+      ## Event Response
+      <SchemaDefinition schemaRef="#/components/schemas/EventResponse" />
+
+      ## Impression Response
+      <SchemaDefinition schemaRef="#/components/schemas/ImpressionResponse" />
+
+      ## Topsort Error
+      <SchemaDefinition schemaRef="#/components/schemas/TopsortError" />
 
 security:
   - BearerAuth: []
@@ -527,8 +595,6 @@ components:
             - categoryPage
             - searchPage
 
-    # Error Codes
-
     TopsortError:
       type: object
       required:
@@ -555,7 +621,7 @@ components:
             - too_few_impressions
             - too_few_slots
         docUrl:
-          enum: ['https://topsort.redoc.ly']
+          enum: ['https://topsort-api.redoc.ly']
         message:
           type: string
 

--- a/topsort-endpoints.yml
+++ b/topsort-endpoints.yml
@@ -26,11 +26,11 @@ tags:
   - name: Models
     x-displayName: All Models
     description: |
+      ## Auction
+      <SchemaDefinition schemaRef="#/components/schemas/Auction" />
+
       ## Auction Request (Full Definition)
       <SchemaDefinition schemaRef="#/components/schemas/AuctionRequest" />
-
-      ## Auction Request (Sponsored Listings)
-      <SchemaDefinition schemaRef="#/components/schemas/AuctionRequestSponsoredListings" />
 
       ## Auction Request (General Banners)
       <SchemaDefinition schemaRef="#/components/schemas/AuctionRequestGeneralBanners" />
@@ -38,59 +38,59 @@ tags:
       ## Auction Request (Homepage Standalone Banners)
       <SchemaDefinition schemaRef="#/components/schemas/AuctionRequestHomepageStandaloneBanners" />
 
-      ## Listings Slots
-      <SchemaDefinition schemaRef="#/components/schemas/ListingsSlots" />
-
-      ## Banners Slots
-      <SchemaDefinition schemaRef="#/components/schemas/BannersSlots" />
-
-      ## Product
-      <SchemaDefinition schemaRef="#/components/schemas/Product" />
-
-      ## Vendor
-      <SchemaDefinition schemaRef="#/components/schemas/Vendor" />
-
-      ## Session
-      <SchemaDefinition schemaRef="#/components/schemas/Session" />
+      ## Auction Request (Sponsored Listings)
+      <SchemaDefinition schemaRef="#/components/schemas/AuctionRequestSponsoredListings" />
 
       ## Banner Options
       <SchemaDefinition schemaRef="#/components/schemas/BannerOptions" />
 
-      ## Auction
-      <SchemaDefinition schemaRef="#/components/schemas/Auction" />
-
-      ## Winner
-      <SchemaDefinition schemaRef="#/components/schemas/Winner" />
-
-      ## Event
-      <SchemaDefinition schemaRef="#/components/schemas/Event" />
-
-      ## Impression Event
-      <SchemaDefinition schemaRef="#/components/schemas/ImpressionEvent" />
+      ## Banners Slots
+      <SchemaDefinition schemaRef="#/components/schemas/BannersSlots" />
 
       ## Click Event
       <SchemaDefinition schemaRef="#/components/schemas/ClickEvent" />
 
-      ## Purchase Event
-      <SchemaDefinition schemaRef="#/components/schemas/PurchaseEvent" />
-
-      ## Placement
-      <SchemaDefinition schemaRef="#/components/schemas/Placement" />
-
-      ## Impression
-      <SchemaDefinition schemaRef="#/components/schemas/Impression" />
-
-      ## Purchase Item
-      <SchemaDefinition schemaRef="#/components/schemas/PurchaseItem" />
+      ## Event
+      <SchemaDefinition schemaRef="#/components/schemas/Event" />
 
       ## Event Response
       <SchemaDefinition schemaRef="#/components/schemas/EventResponse" />
 
+      ## Impression
+      <SchemaDefinition schemaRef="#/components/schemas/Impression" />
+
+      ## Impression Event
+      <SchemaDefinition schemaRef="#/components/schemas/ImpressionEvent" />
+
       ## Impression Response
       <SchemaDefinition schemaRef="#/components/schemas/ImpressionResponse" />
 
+      ## Listings Slots
+      <SchemaDefinition schemaRef="#/components/schemas/ListingsSlots" />
+
+      ## Placement
+      <SchemaDefinition schemaRef="#/components/schemas/Placement" />
+
+      ## Product
+      <SchemaDefinition schemaRef="#/components/schemas/Product" />
+
+      ## Purchase Event
+      <SchemaDefinition schemaRef="#/components/schemas/PurchaseEvent" />
+
+      ## Purchase Item
+      <SchemaDefinition schemaRef="#/components/schemas/PurchaseItem" />
+
+      ## Session
+      <SchemaDefinition schemaRef="#/components/schemas/Session" />
+
       ## Topsort Error
       <SchemaDefinition schemaRef="#/components/schemas/TopsortError" />
+
+      ## Vendor
+      <SchemaDefinition schemaRef="#/components/schemas/Vendor" />
+
+      ## Winner
+      <SchemaDefinition schemaRef="#/components/schemas/Winner" />
 
 security:
   - BearerAuth: []


### PR DESCRIPTION
We use the workaround described in https://github.com/Redocly/redoc/issues/134 to display the models as an API section. We also fix a typo, a documentation reference and remove a redundant comment.