### PR TITLE
fix: use structurally valid resolvedBidId in examples

### DIFF
--- a/topsort-api-v1.yml
+++ b/topsort-api-v1.yml
@@ -310,7 +310,7 @@ components:
         resolvedBidId:
           type: string
           description: An opaque topsort ID to be used when this item is interacted with.
-          example: 'b23f2d4b-ec5d-465f-b399-fed34fc020c7'
+          example: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
         assetUrl:
           type: string
           description: The vendor defined asset that the marketplace has to use as a banner.
@@ -427,7 +427,7 @@ components:
               example: '2009-01-01T12:59:59-05:00'
             resolvedBidId:
               type: string
-              example: 'b23f2d4b-ec5d-465f-b399-fed34fc020c7'
+              example: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
       example:
         eventType: Click
         session:
@@ -435,7 +435,7 @@ components:
         placement:
           page: Search-page
           location: listing-1
-        resolvedBidId: oXuTYeFWxaRdhlUK7lIUQjGd
+        resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
 
     ImpressionEvent:
       description: A product has become visible to the consumer. In case you cannot send the impression when the product is visible, send us an impression event when the product was rendered in the HTML or if that's also not possible when your API returns the results. It is important to select the most specific event so that your vendors have more accurate CTR metrics, which allow them to better predict their campaigns.
@@ -451,11 +451,11 @@ components:
               items:
                 $ref: '#/components/schemas/Impression'
               example:
-                - resolvedBidId: oXuTYeFWxaRdhlUK7lIUQjGd
+                - resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
                   placement:
                     page: Search-page
                     location: listing-1
-                - resolvedBidId: K0NmH1qlSTFKA4GterHxdY5l
+                - resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
                   placement:
                     page: Search-page
                     location: listing-2
@@ -486,7 +486,7 @@ components:
           example: 234f678-f90c
         resolvedBidId:
           type: string
-          example: 'b23f2d4b-ec5d-465f-b399-fed34fc020c7'
+          example: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
 
     PurchaseEvent:
       description: The consumer has purchased some products.
@@ -541,11 +541,11 @@ components:
           example: 1295
         resolvedBidId:
           type: string
-          example: 'b23f2d4b-ec5d-465f-b399-fed34fc020c7'
+          example: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
       example:
         productId: p_SA0238
         unitPrice: 1295
-        resolvedBidId: oXuTYeFWxaRdhlUK7lIUQjGd
+        resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
 
     ImpressionResponse:
       type: object

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -110,16 +110,16 @@ paths:
                         - rank: 0
                           winnerType: product
                           winnerId: b_Mfk15
-                          resolvedBidId: b23f2d4b-ec5d-465f-b399-2344fc020c7
+                          resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
                         - rank: 1
                           winnerType: product
                           winnerId: e_PJbnN
-                          resolvedBidId: 3aaa25fe-60a0-45a3-ae65-39ec1b525eb4
+                          resolvedBidId: WyJlX1BKYm5OIiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
                     - winners:
                         - rank: 0
                           winnerType: product
                           winnerId: e_PJbnN
-                          resolvedBidId: 3aaa25fe-60a0-45a3-ae65-39ec1b525eb4
+                          resolvedBidId: WyJlX1BKYm5OIiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwiYmFubmVyQWRzIiwiZGVmYXVsdCIsIiJd
                           assetUrl: https://topsort.cdnprovider.com/lhs-banner-image-for-e_PJbnN.png
         401:
           $ref: '#/components/responses/UnauthorizedError'
@@ -285,7 +285,7 @@ components:
         resolvedBidId:
           type: string
           description: An opaque Topsort ID to be used when this item is interacted with.
-          example: b23f2d4b-ec5d-465f-b399-fed34fc020c7
+          example: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
         assetUrl:
           type: string
           format: uri


### PR DESCRIPTION
This was breaking requests from the `Try me!` sections.