### PR TITLE
chore(v2): remove AuctionRequest from All Models section

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -27,9 +27,6 @@ tags:
       ## Auction
       <SchemaDefinition schemaRef="#/components/schemas/Auction" />
 
-      ## Auction Request
-      <SchemaDefinition schemaRef="#/components/schemas/AuctionRequest" />
-
       ## Auction Request (Banners)
       <SchemaDefinition schemaRef="#/components/schemas/AuctionRequestBanners" />
 


### PR DESCRIPTION
The hack to display models in Redocly (with a `SchemaDefinition` JSX injection) does not work with multiple options, so any dropdowns based on discriminators are broken; this change hides that broken entry from the list of models.