### PR TITLE
fix: use camel case in JSON body

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -448,7 +448,7 @@ components:
             minLength: 1
           minItems: 1
           maxItems: 10000
-        quality_scores:
+        qualityScores:
           type: array
           description: |
             An array of marketplace defined quality scores, each corresponding to the product ID with matching array index.


### PR DESCRIPTION
Update schema according to the changes in https://github.com/Topsort/auction-engine/pull/1358. As far as we know, no one is using this yet.