### PR TITLE
chore: forbid additional properties for events v2

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -168,6 +168,8 @@ paths:
                           asset:
                             - url: https://topsort.cdnprovider.com/lhs-banner-image-for-p_PJbnN-1x.png
                       error: false
+                    - winners: {}
+                      error: false
         401:
           $ref: '#/components/responses/UnauthorizedError'
         400:

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -572,31 +572,26 @@ components:
     EventsRequest:
       type: object
       additionalProperties: false
-      anyOf:
-        - type: object
-          properties:
-            impressions:
-              type: array
-              items:
-                $ref: '#/components/schemas/Impression'
-              minItems: 1
-              maxItems: 50
-        - type: object
-          properties:
-            clicks:
-              type: array
-              items:
-                $ref: '#/components/schemas/Click'
-              minItems: 1
-              maxItems: 50
-        - type: object
-          properties:
-            purchases:
-              type: array
-              items:
-                $ref: '#/components/schemas/Purchase'
-              minItems: 1
-              maxItems: 50
+      properties:
+        impressions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Impression'
+          minItems: 1
+          maxItems: 50
+        clicks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Click'
+          minItems: 1
+          maxItems: 50
+        purchases:
+          type: array
+          items:
+            $ref: '#/components/schemas/Purchase'
+          minItems: 1
+          maxItems: 50
+      minProperties: 1
     Impression:
       type: object
       description: >

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Topsort Endpoints API Reference
   description: >-
@@ -593,44 +593,38 @@ components:
           maxItems: 50
       minProperties: 1
       examples:
-        Impressions:
-          value:
-            impressions:
-              - occurredAt: '2019-01-01T12:59:59-05:00'
-                opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
-                id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
-                resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
-                placement:
-                  path: /categories/dairy
-                  position: 1
-                  page: 1
-                  pageSize: 15
-                  categoryId: 9BLIe
-        Clicks:
-          value:
-            clicks:
-              - occurredAt: '2019-01-01T13:01:42-05:00'
-                opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
-                id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
-                resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
-                placement:
-                  path: /categories/dairy
-                  position: 1
-                  page: 1
-                  pageSize: 15
-                  categoryId: 9BLIe
-        Purchases:
-          value:
-            purchases:
-              - occurredAt: '2019-01-01T12:59:59-05:00'
-                opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
-                id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
-                items:
-                  - productId: p_SA0238
-                    unitPrice: 12.95
-                    quantity: 2
-                  - productId: p_oajf2D
-                    unitPrice: 1.49
+        - impressions:
+          - occurredAt: '2019-01-01T12:59:59-05:00'
+            opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
+            id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+            resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
+            placement:
+              path: /categories/dairy
+              position: 1
+              page: 1
+              pageSize: 15
+              categoryId: 9BLIe
+        - clicks:
+          - occurredAt: '2019-01-01T13:01:42-05:00'
+            opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
+            id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+            resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
+            placement:
+              path: /categories/dairy
+              position: 1
+              page: 1
+              pageSize: 15
+              categoryId: 9BLIe
+        - purchases:
+          - occurredAt: '2019-01-01T12:59:59-05:00'
+            opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
+            id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+            items:
+              - productId: p_SA0238
+                unitPrice: 12.95
+                quantity: 2
+              - productId: p_oajf2D
+                unitPrice: 1.49
     Impression:
       type: object
       description: >

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -19,7 +19,7 @@ info:
 servers:
   - url: https://<slug>.api.sandbox.topsort.ai/v2
     description: Sandbox server (uses test data)
-  - url: https://<slug>.api.topsort.ai//v2
+  - url: https://<slug>.api.topsort.ai/v2
     description: Production server (uses live data)
 
 tags:

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -593,38 +593,44 @@ components:
           maxItems: 50
       minProperties: 1
       examples:
-        - impressions:
-          - occurredAt: '2019-01-01T12:59:59-05:00'
-            opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
-            id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
-            resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
-            placement:
-              path: /categories/dairy
-              position: 1
-              page: 1
-              pageSize: 15
-              categoryId: 9BLIe
-        - clicks:
-          - occurredAt: '2019-01-01T13:01:42-05:00'
-            opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
-            id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
-            resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
-            placement:
-              path: /categories/dairy
-              position: 1
-              page: 1
-              pageSize: 15
-              categoryId: 9BLIe
-        - purchases:
-          - occurredAt: '2019-01-01T12:59:59-05:00'
-            opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
-            id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
-            items:
-              - productId: p_SA0238
-                unitPrice: 12.95
-                quantity: 2
-              - productId: p_oajf2D
-                unitPrice: 1.49
+        Impressions:
+          value:
+            impressions:
+              - occurredAt: '2019-01-01T12:59:59-05:00'
+                opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
+                id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+                resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
+                placement:
+                  path: /categories/dairy
+                  position: 1
+                  page: 1
+                  pageSize: 15
+                  categoryId: 9BLIe
+        Clicks:
+          value:
+            clicks:
+              - occurredAt: '2019-01-01T13:01:42-05:00'
+                opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
+                id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+                resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
+                placement:
+                  path: /categories/dairy
+                  position: 1
+                  page: 1
+                  pageSize: 15
+                  categoryId: 9BLIe
+        Purchases:
+          value:
+            purchases:
+              - occurredAt: '2019-01-01T12:59:59-05:00'
+                opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
+                id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+                items:
+                  - productId: p_SA0238
+                    unitPrice: 12.95
+                    quantity: 2
+                  - productId: p_oajf2D
+                    unitPrice: 1.49
     Impression:
       type: object
       description: >

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.1
 info:
   title: Topsort Endpoints API Reference
   description: >-
@@ -592,45 +592,39 @@ components:
           minItems: 1
           maxItems: 50
       minProperties: 1
-      examples:
-        Impressions:
-          value:
-            impressions:
-              - occurredAt: '2019-01-01T12:59:59-05:00'
-                opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
-                id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
-                resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
-                placement:
-                  path: /categories/dairy
-                  position: 1
-                  page: 1
-                  pageSize: 15
-                  categoryId: 9BLIe
-        Clicks:
-          value:
-            clicks:
-              - occurredAt: '2019-01-01T13:01:42-05:00'
-                opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
-                id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
-                resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
-                placement:
-                  path: /categories/dairy
-                  position: 1
-                  page: 1
-                  pageSize: 15
-                  categoryId: 9BLIe
-        Purchases:
-          value:
-            purchases:
-              - occurredAt: '2019-01-01T12:59:59-05:00'
-                opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
-                id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
-                items:
-                  - productId: p_SA0238
-                    unitPrice: 12.95
-                    quantity: 2
-                  - productId: p_oajf2D
-                    unitPrice: 1.49
+      example:
+        impressions:
+          - occurredAt: '2019-01-01T12:59:59-05:00'
+            opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
+            id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+            resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
+            placement:
+              path: /categories/dairy
+              position: 1
+              page: 1
+              pageSize: 15
+              categoryId: 9BLIe
+        clicks:
+          - occurredAt: '2019-01-01T13:01:42-05:00'
+            opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
+            id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+            resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
+            placement:
+              path: /categories/dairy
+              position: 1
+              page: 1
+              pageSize: 15
+              categoryId: 9BLIe
+        purchases:
+          - occurredAt: '2019-01-01T12:59:59-05:00'
+            opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
+            id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+            items:
+              - productId: p_SA0238
+                unitPrice: 12.95
+                quantity: 2
+              - productId: p_oajf2D
+                unitPrice: 1.49
     Impression:
       type: object
       description: >

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -572,26 +572,31 @@ components:
     EventsRequest:
       type: object
       additionalProperties: false
-      properties:
-        impressions:
-          type: array
-          items:
-            $ref: '#/components/schemas/Impression'
-          minItems: 1
-          maxItems: 50
-        clicks:
-          type: array
-          items:
-            $ref: '#/components/schemas/Click'
-          minItems: 1
-          maxItems: 50
-        purchases:
-          type: array
-          items:
-            $ref: '#/components/schemas/Purchase'
-          minItems: 1
-          maxItems: 50
-      minProperties: 1
+      anyOf:
+        - type: object
+          properties:
+            impressions:
+              type: array
+              items:
+                $ref: '#/components/schemas/Impression'
+              minItems: 1
+              maxItems: 50
+        - type: object
+          properties:
+            clicks:
+              type: array
+              items:
+                $ref: '#/components/schemas/Click'
+              minItems: 1
+              maxItems: 50
+        - type: object
+          properties:
+            purchases:
+              type: array
+              items:
+                $ref: '#/components/schemas/Purchase'
+              minItems: 1
+              maxItems: 50
     Impression:
       type: object
       description: >

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -594,37 +594,37 @@ components:
       minProperties: 1
       example:
         impressions:
-          - occurredAt: '2019-01-01T12:59:59-05:00'
+          - id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+            occurredAt: '2019-01-01T12:59:59-05:00'
             opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
-            id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
-            resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
             placement:
               path: /categories/dairy
               position: 1
               page: 1
               pageSize: 15
               categoryId: 9BLIe
+            resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
         clicks:
-          - occurredAt: '2019-01-01T13:01:42-05:00'
+          - id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+            occurredAt: '2019-01-01T13:01:42-05:00'
             opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
-            id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
-            resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
             placement:
               path: /categories/dairy
               position: 1
               page: 1
               pageSize: 15
               categoryId: 9BLIe
+            resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
         purchases:
-          - occurredAt: '2019-01-01T12:59:59-05:00'
-            opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
-            id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+          - id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
             items:
               - productId: p_SA0238
                 unitPrice: 12.95
                 quantity: 2
               - productId: p_oajf2D
                 unitPrice: 1.49
+            occurredAt: '2019-01-01T12:59:59-05:00'
+            opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
     Impression:
       type: object
       description: >

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -605,7 +605,7 @@ components:
               categoryId: 9BLIe
             resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
         clicks:
-          - id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+          - id: b39d39ed-ea0e-4059-9d15-4990b39c85a2
             occurredAt: '2019-01-01T13:01:42-05:00'
             opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
             placement:
@@ -616,7 +616,7 @@ components:
               categoryId: 9BLIe
             resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
         purchases:
-          - id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+          - id: 0e06c899-b2cd-4e0d-b0de-8aefb4b6d0a0
             items:
               - productId: p_SA0238
                 unitPrice: 12.95

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -3,7 +3,7 @@ info:
   title: Topsort Endpoints API Reference
   description: >-
     In order for a storefront to be able to run auctions in Topsort and report auction-related events back to Topsort,
-    both the /v2/auctions and /v2/events endpoints must be integrated.
+    both the `/v2/auctions` and `/v2/events` endpoints must be integrated.
     Below are the endpoint and model definitions for each.
   contact:
     email: wicha@topsort.com

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1,6 +1,10 @@
 openapi: 3.0.1
 info:
   title: Topsort Endpoints API Reference
+  description: >-
+    In order for a storefront to be able to run auctions in Topsort and report auction-related events back to Topsort,
+    both the /v2/auctions and /v2/events endpoints must be integrated.
+    Below are the endpoint and model definitions for each.
   contact:
     email: wicha@topsort.com
   license:
@@ -517,6 +521,7 @@ components:
       type: object
       required:
         - path
+      additionalProperties: false
       properties:
         path:
           type: string
@@ -566,6 +571,7 @@ components:
           minLength: 1
     EventsRequest:
       type: object
+      additionalProperties: false
       properties:
         impressions:
           type: array
@@ -596,6 +602,7 @@ components:
         - occurredAt
         - opaqueUserId
         - id
+      additionalProperties: false
       properties:
         resolvedBidId:
           type: string
@@ -630,6 +637,7 @@ components:
         - occurredAt
         - opaqueUserId
         - id
+      additionalProperties: false
       properties:
         resolvedBidId:
           type: string
@@ -665,6 +673,7 @@ components:
         - opaqueUserId
         - items
         - id
+      additionalProperties: false
       properties:
         occurredAt:
           type: string
@@ -688,13 +697,14 @@ components:
           description: >
             The marketplace unique ID for the order.
             This field ensures the event reporting is idempotent in case there is a network issue and the request is retried.
-            If there is no unique ID for orders on the marketplace side, generate a unique string that does not change if the event is resent.
+            If there is no unique ID for orders on the marketplace side, generate a unique string that does not change if the event needs to be resent.
           example: 0e06c899-b2cd-4e0d-b0de-8aefb4b6d0a0
     PurchaseItem:
       type: object
       required:
         - productId
         - unitPrice
+      additionalProperties: false
       properties:
         productId:
           type: string
@@ -708,7 +718,7 @@ components:
           example: 2
         unitPrice:
           type: number
-          format: float
+          format: double
           minimum: 0.0
           exclusiveMinimum: true
           description: The price of a single item in the marketplace currency.

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -592,6 +592,45 @@ components:
           minItems: 1
           maxItems: 50
       minProperties: 1
+      examples:
+        Impressions:
+          value:
+            impressions:
+              - occurredAt: '2019-01-01T12:59:59-05:00'
+                opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
+                id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+                resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
+                placement:
+                  path: /categories/dairy
+                  position: 1
+                  page: 1
+                  pageSize: 15
+                  categoryId: 9BLIe
+        Clicks:
+          value:
+            clicks:
+              - occurredAt: '2019-01-01T13:01:42-05:00'
+                opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
+                id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+                resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
+                placement:
+                  path: /categories/dairy
+                  position: 1
+                  page: 1
+                  pageSize: 15
+                  categoryId: 9BLIe
+        Purchases:
+          value:
+            purchases:
+              - occurredAt: '2019-01-01T12:59:59-05:00'
+                opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
+                id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
+                items:
+                  - productId: p_SA0238
+                    unitPrice: 12.95
+                    quantity: 2
+                  - productId: p_oajf2D
+                    unitPrice: 1.49
     Impression:
       type: object
       description: >

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -91,7 +91,7 @@ paths:
         description: >
           The information describing what will be auctioned.
           Topsort will run an auction for each batched auction request, for which products, brands and/or vendors' bids will compete against each other.
-          Provided fields are additive, in the sense that only bids that match all filtering fields are considered (e.g. in the example below, only bids for products in the c_yogurt category that match the "Noosa Peach" search string will participate in the acution).
+          Provided fields are additive, in the sense that only bids that match all filtering fields are considered (e.g. in the example below, only bids for products in the c_yogurt category that match the "Noosa Peach" search string will participate in the auction).
         content:
           application/json:
             schema:


### PR DESCRIPTION
Schema:
- [v2/events] forbid any additional properties for events v2 request schema.
- [v2/events] change `purchaseItems`' unit price format to the 64-bit precision `double`.

Docs:
- [v2] add an API description.
- [v2] fix server URL.
- [v2/auctions] fix response example to match the request cardinality.
- [v2/events] add request example.
