### PR TITLE
chore: allow multiple categories in API v2

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -217,13 +217,13 @@ components:
   schemas:
     Category:
       type: object
-      description: An object describing the category of the bids that will participate in an auction.
+      description: An object describing a category of the bids that will participate in an auction.
       required:
         - id
       properties:
         id:
           type: string
-          description: The marketplace's ID of the category for which an auction will be run.
+          description: A marketplace's ID of one the categories for which an auction will be run.
           example: c_yogurt
 
     Device:
@@ -246,7 +246,7 @@ components:
 
     AuctionRequestSponsoredListings:
       type: object
-      # TODO: add back category and searchQuery to description when supported
+      # TODO: add back categories and searchQuery to description when supported
       description: >
         Describes the intent of running a sponsored listings auction.
         At least one of the following fields must be set: category,
@@ -262,8 +262,14 @@ components:
           format: int32
           minimum: 1
           description: Specifies the maximum number of auction winners that should be returned.
-        # category:
-        #   $ref: '#/components/schemas/Category'
+        # categories:
+        #   type: array
+        #   description: >
+        #     An array containing the categories of the bids that will participate in an auction.
+        #     The product associated to the bid must belong to all of the categories in the request.
+        #   items:
+        #     $ref: '#/components/schemas/Category'
+        #   minItems: 1
         # searchQuery:
         #   type: string
         #   description: The search string provided by a user.
@@ -559,12 +565,17 @@ components:
             The ID of the product associated to this event.
             This field is used to disambiguate between products from the same PDP.
           minLength: 1
-        categoryId:
-          type: string
+        categoryIds:
+          type: array
+          items:
+            type: string
+            minLength: 1
+            uniqueItems: true
+            description: A category ID.
           description: >
-            The ID of the category associated to the page in which this event occurred, if applicable.
-            This ID must match the ID provided through the catalog service.
-          minLength: 1
+            An array of IDs of the categories associated to the page in which this event occurred, if applicable.
+            These IDs must match the IDs provided through the catalog service.
+          minItems: 1
         searchQuery:
           type: string
           description: >

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -223,7 +223,8 @@ components:
       properties:
         id:
           type: string
-          description: The marketplace's ID of the category.
+          description: The ID of the category.
+          minLength: 1
           example: c_yogurt
 
     Device:

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -217,13 +217,13 @@ components:
   schemas:
     Category:
       type: object
-      description: An object describing a category of the bids that will participate in an auction.
+      description: An object describing a category for the purpose of running an auction.
       required:
         - id
       properties:
         id:
           type: string
-          description: A marketplace's ID of one the categories for which an auction will be run.
+          description: The marketplace's ID of the category.
           example: c_yogurt
 
     Device:
@@ -266,7 +266,7 @@ components:
           type: array
           description: >
             An array containing the categories of the bids that will participate in an auction.
-            The product associated to the bid must belong to all of the categories in the request.
+            In order to participate in the auction, the product associated to a bid must belong to all of the categories in the request.
           items:
             $ref: '#/components/schemas/Category'
           minItems: 1

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -262,14 +262,14 @@ components:
           format: int32
           minimum: 1
           description: Specifies the maximum number of auction winners that should be returned.
-        # categories:
-        #   type: array
-        #   description: >
-        #     An array containing the categories of the bids that will participate in an auction.
-        #     The product associated to the bid must belong to all of the categories in the request.
-        #   items:
-        #     $ref: '#/components/schemas/Category'
-        #   minItems: 1
+        categories:
+          type: array
+          description: >
+            An array containing the categories of the bids that will participate in an auction.
+            The product associated to the bid must belong to all of the categories in the request.
+          items:
+            $ref: '#/components/schemas/Category'
+          minItems: 1
         # searchQuery:
         #   type: string
         #   description: The search string provided by a user.


### PR DESCRIPTION
## Changes

Change `category` fields for sponsored listings so that multiple (conjunctive) categories may be provided at once.
- Updates the (commented out) category field in auctions v2.
- Updates the placement field in events v2.