### PR TITLE
chore: use slot IDs for banner ads instead of aspect ratios

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -117,7 +117,7 @@ paths:
                       location: New York
                   - type: banners
                     slots: 1
-                    slotId: 254b6dfc-3447-4ddf-a270-ed23101023ef
+                    slotId: categories-ribbon-banner
                     category:
                       id: c_yogurt
                   - type: banners
@@ -321,11 +321,17 @@ components:
           $ref: '#/components/schemas/Device'
         slotId:
           type: string
-          description: >
-            The ID of the region for which this auction will be run for.
-            It must match the values provided when creating the banner campaign.
-            This can be a DOM `id` property for the element where the banner will appear.
+          description: The ID of the banner placement for which this auction will be run for.
           minLength: 1
+        aspectRatio:
+          type: string
+          pattern: '^\d+:\d+$'
+          description: |
+            **Deprecated: use slotId instead.**
+
+            The aspect ratio for a specific slot for a banner placement in the marketplace app.
+            The aspect ratio for the category (or home page, if no category ID was provided in the request) must have been previously set up in the Topsort app.
+          deprecated: true
       required:
         - type
         - slots
@@ -333,7 +339,7 @@ components:
       example:
         type: banners
         slots: 1
-        slotId: 254b6dfc-3447-4ddf-a270-ed23101023ef
+        slotId: categories-ribbon-banner
         category:
           id: c_yogurt
 

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -117,7 +117,7 @@ paths:
                       location: New York
                   - type: banners
                     slots: 1
-                    aspectRatio: '4:1'
+                    slotId: 254b6dfc-3447-4ddf-a270-ed23101023ef
                     category:
                       id: c_yogurt
                   - type: banners
@@ -319,20 +319,21 @@ components:
           description: The search string provided by a user.
         device:
           $ref: '#/components/schemas/Device'
-        aspectRatio:
+        slotId:
           type: string
-          pattern: '^\d+:\d+$'
           description: >
-            The aspect ratio for a specific slot for a banner placement in the marketplace app.
-            The aspect ratio for the category (or home page, if no category ID was provided in the request) must have been previously set up in the Topsort app.
+            The ID of the region for which this auction will be run for.
+            It must match the values provided when creating the banner campaign.
+            This can be a DOM `id` property for the element where the banner will appear.
+          minLength: 1
       required:
         - type
         - slots
-        - aspectRatio
+        - slotId
       example:
         type: banners
         slots: 1
-        aspectRatio: '4:1'
+        slotId: 254b6dfc-3447-4ddf-a270-ed23101023ef
         category:
           id: c_yogurt
 
@@ -494,7 +495,6 @@ components:
             - invalid_event_type
             - invalid_promotion_type
             - invalid_session
-            - missing_aspect_ratio
             - missing_auctions
             - missing_context
             - missing_placement

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -508,6 +508,7 @@ components:
             - missing_promotion_type
             - missing_purchased_at
             - missing_session
+            - missing_slot_id
             - missing_slots
             - no_products
             - no_purchase_items


### PR DESCRIPTION
### Changes

Document new `slotId` as implemented by https://github.com/Topsort/auction-engine/pull/1555.