### PR TITLE
Fix ReadMe Integration.

### DIFF
--- a/.github/workflows/readme-v2-auctions.yml
+++ b/.github/workflows/readme-v2-auctions.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Run `openapi` command (v1) 🚀
         uses: readmeio/rdme@v8
         with:
-          rdme: openapi topsort-api-v1.yml --key=${{ secrets.README_API_KEY }} --id=64b8176948bac8000ca009eb
+          rdme: openapi topsort-api-v1.yml --key=${{ secrets.README_API_KEY }} --id=65492281f39360089af5618d
       - name: Run `openapi` command  (v2) 🚀
         uses: readmeio/rdme@v8
         with:
-          rdme: openapi topsort-api-v2.yml --key=${{ secrets.README_API_KEY }} --id=64b817c1420f5800300ed67e
+          rdme: openapi topsort-api-v2.yml --key=${{ secrets.README_API_KEY }} --id=65491b9bd1d00c001fcd1b67

--- a/topsort-api-v1.yml
+++ b/topsort-api-v1.yml
@@ -76,6 +76,13 @@ security:
   - BearerAuth: []
 
 paths:
+  /fake:
+    get:
+      summary: Fake route to keep ReadMe happy.
+      operationId: fake
+      responses:
+        204:
+          description: No content
   /auctions:
     post:
       tags:

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -87,6 +87,13 @@ security:
   - BearerAuth: []
 
 paths:
+  /fake:
+    get:
+      summary: Fake route to keep ReadMe happy.
+      operationId: fake
+      responses:
+        204:
+          description: No content
   /auctions:
     post:
       tags:


### PR DESCRIPTION
To avoid further problems, we added fake endpoints, so we don't move every page from the ReadMe generated category. Moving every page is the cause of breakage.