### PR TITLE
chore: mark v1 endpoints as deprecated

### DIFF
--- a/topsort-api-v1.yml
+++ b/topsort-api-v1.yml
@@ -85,6 +85,7 @@ paths:
           description: No content
   /auctions:
     post:
+      deprecated: true
       tags:
         - Auctions
       summary: Creates a new auction
@@ -118,6 +119,7 @@ paths:
 
   /events:
     post:
+      deprecated: true
       tags:
         - Events
       summary: Report an event


### PR DESCRIPTION
These endpoints have been replace by version 2 for a couple years now, and have been described as depreacted in the Readme Docs. See https://docs.topsort.com/reference/events and https://docs.topsort.com/reference/auctions.