### PR TITLE
chore(auctions-v1): deprecate sessionId

### DIFF
--- a/topsort-api-v1.yml
+++ b/topsort-api-v1.yml
@@ -180,6 +180,7 @@ components:
           minItems: 1
         session:
           $ref: '#/components/schemas/Session'
+          deprecated: true
         geoTargeting:
           $ref: '#/components/schemas/GeoTargeting'
       example:
@@ -292,14 +293,6 @@ components:
           type: string
           minLength: 1
           example: ebeaf802-6d0a-41a3-ae59-661887c4f6cb
-        # consumerId:
-        #   description: >
-        #     Optional ID identifying the user, this field is required in case your marketplace wants to do cross-device attribution.
-        #
-        #     Instead of sending us the exact same user ID you are storing in your systems we recommend you to send us a hash of the user ID (SHA1, SHA512, etc).
-        #     This field is needed for cross-device attribution.
-        #   type: string
-        #   example: cid_86hkz2p3171joer80pdkltu7n
 
     Placement:
       type: object


### PR DESCRIPTION
This field has since long not being used.

We also remove commented out code.