### PR TITLE
docs: add vendor id definition for purchases

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -957,6 +957,7 @@ components:
               - productId: p_SA0238
                 unitPrice: 12.95
                 quantity: 2
+                vendorId: v_8fj2D
               - productId: p_oajf2D
                 unitPrice: 1.49
             occurredAt: '2019-01-01T12:59:59-05:00'
@@ -1141,6 +1142,11 @@ components:
           exclusiveMinimum: true
           description: The price of a single item in the marketplace currency.
           example: 12.95
+        vendorId:
+          type: string
+          description: The marketplace ID of the vendor selling the product.
+          minLength: 1
+          example: v_8fj2D
 
   securitySchemes:
     BearerAuth:

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1144,7 +1144,9 @@ components:
           example: 12.95
         vendorId:
           type: string
-          description: The marketplace ID of the vendor selling the product.
+          description: >
+            The vendor ID of the product being purchased. This field is optional 
+            and should be filled in if a product is sold by multiple vendors.
           minLength: 1
           example: v_8fj2D
 


### PR DESCRIPTION
Adds the optional vendor id definition for purchases to our docs