### PR TITLE
chore: add campaign id to v2 winner example

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -167,22 +167,26 @@ paths:
                           type: product
                           id: p_Mfk11
                           resolvedBidId: WyJiX01mazExIiwiMTJhNTU4MjgtOGVhZC00Mjk5LTMyNjYtY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0==
+                          campaignId: 82588593-85c5-47c0-b125-07e315b7f2b3
                       error: false
                     - winners:
                         - rank: 1
                           type: product
                           id: p_Mfk15
                           resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
+                          campaignId: 4bcc6093-f367-4df2-aa1b-7c1674dd6441
                         - rank: 2
                           type: product
                           id: p_PJbnN
                           resolvedBidId: WyJlX1BKYm5OIiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
+                          campaignId: a72e4e43-55b5-4d08-81bb-cbb57df59c72
                       error: false
                     - winners:
                         - rank: 1
                           type: product
                           id: p_PJbnN
                           resolvedBidId: WyJlX1BKYm5OIiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwiYmFubmVyQWRzIiwiZGVmYXVsdCIsIiJd
+                          campaignId: 1156ef4e-0109-4190-ac97-4436c82358d2
                           asset:
                             - url: https://topsort.cdnprovider.com/lhs-banner-image-for-p_PJbnN-1x.png
                       error: false
@@ -1138,7 +1142,7 @@ components:
         vendorId:
           type: string
           description: >
-            The vendor ID of the product being purchased. This field is optional 
+            The vendor ID of the product being purchased. This field is optional
             and should be filled in if a product is sold by multiple vendors.
           minLength: 1
           example: v_8fj2D

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -529,6 +529,7 @@ components:
         - type
         - id
         - resolvedBidId
+        - campaignId
       properties:
         rank:
           type: integer
@@ -555,6 +556,10 @@ components:
           type: string
           description: An opaque Topsort ID to be used when this item is interacted with.
           example: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
+        campaignId:
+          type: string
+          description: The ID of the campaign that won the auction.
+          example: 4bcc6093-f367-4df2-aa1b-7c1674dd6441
 
     BannersWinner:
       type: object
@@ -590,6 +595,10 @@ components:
           type: string
           description: An opaque Topsort ID to be used when this item is interacted with.
           example: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
+        campaignId:
+          type: string
+          description: The ID of the campaign that won the auction.
+          example: 4bcc6093-f367-4df2-aa1b-7c1674dd6441
         asset:
           description: The list of available sources for a banner.
           type: array


### PR DESCRIPTION
This PR adds the `campaignId` as part of `/v2/auctions` winners example
<img width="827" alt="image" src="https://github.com/user-attachments/assets/ece6d5bd-6466-4b6f-b1b8-a8c3e79b36e7">
