### PR TITLE
chore: add recommendation for max products in auction

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -654,7 +654,9 @@ components:
       properties:
         ids:
           type: array
-          description: An array of product IDs that should participate in the auction.
+          description: >
+            An array of product IDs that should participate in the auction.
+            We recommend sending no more than 500 products per auction.
           items:
             type: string
             description: >


### PR DESCRIPTION
Add recommendation for maximum amount of products to send on an auction.
This will not be enforced on engine (that's why it is a recommendation), but we will start introducing some limits.