### PR TITLE
fix: format text and add link to opaque uid from auctions

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1196,16 +1196,14 @@ components:
           example: '2009-01-01T12:59:59-05:00'
         opaqueUserId:
           type: string
-          description: |
-            <p>The opaque user ID allows correlating user activity, such as Impressions, Clicks and Purchases,
-            whether or not they are actually logged in. It must be long lived (at least a year) so that Topsort can attribute purchases.
-            </p>
-            <p>
-            If your users are always logged in you may use a hash of your customer ID.
-            If your users may interact with your app or site while logged out we
-            recommend generating a random identifier (UUIDv4) on first load and store it on
-            local storage (cookie, local storage, etc) and let it live for at least a year.
-            </p>
+          description:
+            An anonymized unique identifier that maps to the original user ID without revealing the original value and
+            should match the value used for auctions. The opaque user ID allows correlating user activity, such as
+            Impressions, Clicks and Purchases, whether or not they are actually logged in. It must be long lived
+            (at least a year) so that Topsort can attribute purchases. If your users are always logged in you may use
+            a hash of your customer ID. If your users may interact with your app or site while logged out we recommend
+            generating a random identifier (UUIDv4) on first load and store it on local storage (cookie, local storage,
+            etc) and let it live for at least a year.
           minLength: 1
           example: 71303ce0-de89-496d-8270-6434589615e8
         id:


### PR DESCRIPTION
The field description wasn't formatted correctly and was missing text specifying the continuity of opaque uid between auctions and events.