### PR TITLE
chore: refactor events description

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -297,16 +297,16 @@ paths:
       tags:
         - Events
       summary: Report events
+      description: |
+        Use the `/events` endpoint to notify Topsort about significant user interactions on the marketplace app:
+        - **Impressions** — a promotable was shown to a user.
+        - **Clicks** — a user clicked on a promotable.
+        - **Purchases** — a user created an order.
+
+        For promoted interactions, include the `resolvedBidId` field from the `/v2/auctions` response.
+        For unpromoted interactions, include the `entity` field to describe what was interacted with.
       operationId: reportEvents
       requestBody:
-        description: |
-          Use the `/events` endpoint to notify Topsort about significant consumer interactions on the marketplace app:
-          - **Impressions** — a set of impressions means such promotables have become visible to the consumer.
-          - **Clicks** — a click is sent to Topsort when the consumer has clicked on a promotable.
-          - **Purchases** — a purchase is sent to Topsort once a consumer places an order.
-
-          For promoted interactions, include the `resolvedBidId` field from the `/v2/auctions` response.
-          For unpromoted interactions, include the `entity` field to describe what was interacted with.
         content:
           application/json:
             schema:

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -93,7 +93,7 @@ paths:
         - Auctions
       summary: Create auctions
       description: |
-        Use the `/auctions` endpoint to create and run auctions. Each batch of auction requests can be a mix of 
+        Use the `/auctions` endpoint to create auctions. Each batch of auction requests can be a combination of 
         sponsored listing auctions and banner auctions. Each auction type has a unique body schemas.
       operationId: createAuctions
       requestBody:
@@ -301,13 +301,13 @@ paths:
         - Events
       summary: Report events
       description: |
-        Use the `/events` endpoint to notify Topsort about significant user interactions on the marketplace app:
+        Use the `/events` endpoint to report user interactions and activity in on a marketplace:
         - **Impressions** — a user viewed an asset.
         - **Clicks** — a user clicked on an asset.
         - **Purchases** — a user created an order.
 
         Interactions require either a `resolvedBidId` from the `/v2/auctions` response or an `entity` that describes 
-        the asset.
+        the entity to attribute.
       operationId: reportEvents
       requestBody:
         content:

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -92,6 +92,9 @@ paths:
       tags:
         - Auctions
       summary: Create auctions
+      description: |
+        Use the `/auctions` endpoint to create and run auctions. Each batch of auction requests can be a mix of 
+        sponsored listing auctions and banner auctions. **Note** Banner auctions require the additional `slotId` field.
       operationId: createAuctions
       requestBody:
         description: |

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -94,7 +94,7 @@ paths:
       summary: Create auctions
       description: |
         Use the `/auctions` endpoint to create and run auctions. Each batch of auction requests can be a mix of 
-        sponsored listing auctions and banner auctions. **Note** Banner auctions require the additional `slotId` field.
+        sponsored listing auctions and banner auctions. Each auction type has a unique body schemas.
       operationId: createAuctions
       requestBody:
         description: |
@@ -302,12 +302,12 @@ paths:
       summary: Report events
       description: |
         Use the `/events` endpoint to notify Topsort about significant user interactions on the marketplace app:
-        - **Impressions** — a promotable was shown to a user.
-        - **Clicks** — a user clicked on a promotable.
+        - **Impressions** — a user viewed an asset.
+        - **Clicks** — a user clicked on an asset.
         - **Purchases** — a user created an order.
 
-        For promoted interactions, include the `resolvedBidId` field from the `/v2/auctions` response.
-        For unpromoted interactions, include the `entity` field to describe what was interacted with.
+        Interactions require either a `resolvedBidId` from the `/v2/auctions` response or an `entity` that describes 
+        the asset.
       operationId: reportEvents
       requestBody:
         content:


### PR DESCRIPTION
Noticed that the auction and event post documentations where missing descriptions
![Captura de pantalla 2025-01-08 a la(s) 4 07 17 p  m](https://github.com/user-attachments/assets/428e016f-8052-4239-9279-42a381c599c8)
