### PR TITLE
chore: added opaqueUserId and vendorId as optionals for Sponsored Brands auctions

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1061,6 +1061,8 @@ components:
               $ref: '#/components/schemas/SingleCategory'
             products:
               $ref: '#/components/schemas/Products'
+        opaqueUserId:
+          $ref: '#/components/schemas/OpaqueUserID'
       x-examples:
         Example 1:
           auctions:
@@ -1158,6 +1160,10 @@ components:
         title:
           type: string
           description: An optional title for the sponsored brand selected when creating the campaign.
+        vendorId:
+          type: string
+          description: The ID of the vendor associated with this sponsored brand winner.
+          example: v_8fj2D
         assets:
           description: Assets used to render the sponsored brand ad.
           type: array


### PR DESCRIPTION
Returning vendorId is already supported
opaqueUserId is currently a no-op but will be needed for segments.