### PR TITLE
docs: add placement tracking example for carousel analytics

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -323,6 +323,12 @@ paths:
 
         Interactions require either a `resolvedBidId` from the `/v2/auctions` response or an `entity` that describes 
         the entity to attribute.
+
+        For analytics purposes, you can use the `placement` field to differentiate different listings or banners.
+        For example, on a product page with a carousel of products, you can track impressions and clicks related to the carousel
+        by including `/carousel` at the end of the `path` field in the `placement` object. This allows you to monitor
+        the performance of carousel products in the [Data Room](https://docs.topsort.com/knowledge-base/analytics/data-room/).
+
       operationId: reportEvents
       requestBody:
         content:


### PR DESCRIPTION
jira ticket https://topsort.atlassian.net/jira/software/projects/INTE/boards/21?assignee=712020%3Abfdce163-008e-49fc-8c99-27501fc7d3b1&selectedIssue=INTE-1516


We add a use case in the report events documentation where a user can track different sections of the same page using the placement object, which they can later differentiate via the Data Room for analytics.

Swagger UI render:
![imagen](https://github.com/user-attachments/assets/b7a2e705-ad47-43b3-a176-4ed705fee9d7)
