### PR TITLE
chore: update events endpoint to reflect api

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -98,6 +98,9 @@ tags:
       ## RankingWinner
       <SchemaDefinition schemaRef="#/components/schemas/RankingWinner" />
 
+      ## Interaction Object
+      <SchemaDefinition schemaRef="#/components/schemas/InteractionObject" />
+
 security:
   - BearerAuth: []
 
@@ -1080,6 +1083,30 @@ components:
           type: string
           description: An opaque Topsort ID to be used when this item is interacted with.
           example: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
+    
+    InteractionObject:
+      type: object
+      required:
+        - type
+      properties:
+        type: 
+          type: string
+          description: The type of object that is being reported on the interaction. 
+          enum:
+            - listing
+            - banner
+        assetId:
+          type: string
+          description: When type is `banner`, signals the ID of the asset of the banner
+          example: banner_asset_001
+        clickType:
+          type: string
+          description: When type is `listing`, signals the specific interaction flavor wth the listing.
+          enum:
+            - product
+            - like
+            - add-to-cart
+          
 
     # Dimensions:
     #   type: object
@@ -1713,6 +1740,10 @@ components:
             the `additionalAttribution` field. When using this field, the `resolvedBidId` must also exist
             in the event body.
           $ref: '#/components/schemas/Entity'
+        page:
+          $ref: '#/components/schemas/Page'
+        object:
+          $ref: '#/components/schemas/InteractionObject'
 
     Click:
       description: >
@@ -1756,6 +1787,11 @@ components:
             the `additionalAttribution` field. When using this field, the `resolvedBidId` must also exist
             in the event body.
           $ref: '#/components/schemas/Entity'
+        page:
+          $ref: '#/components/schemas/Page'
+        object:
+          $ref: '#/components/schemas/InteractionObject'
+        
     Purchase:
       description: >
         A purchase is sent to Topsort once a marketplace customer places an order.

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1094,6 +1094,7 @@ components:
 
     InteractionObject:
       type: object
+      description: Information regarding an organic or non-sponsored event.
       required:
         - type
       properties:
@@ -1806,6 +1807,13 @@ components:
           $ref: '#/components/schemas/Page'
         object:
           $ref: '#/components/schemas/InteractionObject'
+        clickType:
+          type: string
+          description: For sponsored events only, signals the specific interaction flavor with the listing.
+          enum:
+            - product
+            - like
+            - add-to-cart
         externalCampaignId:
           type: string
           description: Marketplace provided ID for a campaign

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -378,9 +378,10 @@ paths:
         - **Impressions** — a user viewed an asset.
         - **Clicks** — a user clicked on an asset.
         - **Purchases** — a user created an order.
+        - **Pageviews** - a user navigate on a page.
 
-        Interactions require either a `resolvedBidId` from the `/v2/auctions` response or an `entity` that describes 
-        the entity to attribute.
+        Interactions require either a `resolvedBidId`, called sponsored events, from the `/v2/auctions` response
+        or an `entity` that describes the entity to attribute, known as organic or non-sponsored event.
 
         For analytics purposes, you can use the `placement` field to differentiate different listings or banners.
         For example, on a product page with a carousel of products, you can track impressions and clicks related to the carousel
@@ -1821,6 +1822,35 @@ components:
             2. you want to use it for halo attribution
           minLength: 1
           example: v_8fj2D
+    Pageview:
+      type: object
+      description: >
+        A page view represents the navigation of the user trougout the page. They are considered organic events.
+        In contrast to clicks or impressions, which are events within a page. A page view is the interaction with the full page page.
+      required:
+        - occurredAt
+        - opaqueUserId
+        - id
+        - page
+      additionalProperties: false
+      properties:
+        page:
+          $ref: '#/components/schemas/Page'
+        occurredAt:
+          type: string
+          format: date-time
+          description: RFC3339 formatted timestamp including UTC offset.
+          example: '2009-01-01T12:59:59-05:00'
+        opaqueUserId:
+          $ref: '#/components/schemas/OpaqueUserID'
+        id:
+          type: string
+          description: >
+            The marketplace's unique ID for the impression.
+            This field ensures the event reporting is idempotent in case there is a network issue and the request is retried.
+            If there is no impression model on the marketplace side, generate a unique string that does not change if the event is resent.
+          minLength: 1
+          example: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
 
   securitySchemes:
     BearerAuth:

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1083,15 +1083,15 @@ components:
           type: string
           description: An opaque Topsort ID to be used when this item is interacted with.
           example: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
-    
+
     InteractionObject:
       type: object
       required:
         - type
       properties:
-        type: 
+        type:
           type: string
-          description: The type of object that is being reported on the interaction. 
+          description: The type of object that is being reported on the interaction.
           enum:
             - listing
             - banner
@@ -1106,7 +1106,6 @@ components:
             - product
             - like
             - add-to-cart
-          
 
     # Dimensions:
     #   type: object
@@ -1744,6 +1743,14 @@ components:
           $ref: '#/components/schemas/Page'
         object:
           $ref: '#/components/schemas/InteractionObject'
+        externalCampaignId:
+          type: string
+          description: Marketplace provided ID for a campaign
+          example: 'awareness-campaign-2025'
+        externalVendorId:
+          type: string
+          description: Marketplace provided ID for a vendor
+          example: 'my-new-vendor'
 
     Click:
       description: >
@@ -1791,7 +1798,15 @@ components:
           $ref: '#/components/schemas/Page'
         object:
           $ref: '#/components/schemas/InteractionObject'
-        
+        externalCampaignId:
+          type: string
+          description: Marketplace provided ID for a campaign
+          example: 'awareness-campaign-2025'
+        externalVendorId:
+          type: string
+          description: Marketplace provided ID for a vendor
+          example: 'my-new-vendor'
+
     Purchase:
       description: >
         A purchase is sent to Topsort once a marketplace customer places an order.

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1101,7 +1101,7 @@ components:
           example: banner_asset_001
         clickType:
           type: string
-          description: When type is `listing`, signals the specific interaction flavor wth the listing.
+          description: When type is `listing`, signals the specific interaction flavor with the listing.
           enum:
             - product
             - like

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -380,8 +380,8 @@ paths:
         - **Purchases** — a user created an order.
         - **Pageviews** - a user navigate on a page.
 
-        Interactions require either a `resolvedBidId`, called sponsored events, from the `/v2/auctions` response
-        or an `entity` that describes the entity to attribute, known as organic or non-sponsored event.
+        Interactions require either a `resolvedBidId`, for sponsored events coming from the `/v2/auctions` response,
+        or an `entity` that describes the entity that was interacted with, in the case of organic or non-sponsored events.
 
         For analytics purposes, you can use the `placement` field to differentiate different listings or banners.
         For example, on a product page with a carousel of products, you can track impressions and clicks related to the carousel
@@ -1825,8 +1825,8 @@ components:
     Pageview:
       type: object
       description: >
-        A page view represents the navigation of the user trougout the page. They are considered organic events.
-        In contrast to clicks or impressions, which are events within a page. A page view is the interaction with the full page page.
+        A page view represents the navigation of the user throughout the page. They are considered organic events.
+        In contrast to clicks or impressions, which are events within a page, a page view is the interaction with the full page, which can contain multiple objects.
       required:
         - occurredAt
         - opaqueUserId
@@ -1846,9 +1846,9 @@ components:
         id:
           type: string
           description: >
-            The marketplace's unique ID for the impression.
+            The marketplace's unique ID for the event.
             This field ensures the event reporting is idempotent in case there is a network issue and the request is retried.
-            If there is no impression model on the marketplace side, generate a unique string that does not change if the event is resent.
+            If there is no pageview model on the marketplace side, generate a unique string that does not change if the event is resent.
           minLength: 1
           example: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
 


### PR DESCRIPTION
Update v2/events API docs with new changes: 

- Pageview event
- Page struct
- externalCampaignID and externalVendorID fields
- clickType field for sponsored events
- Object struct for non sponsored events

Closes: https://topsort.atlassian.net/browse/AE-148