### PR TITLE
fix(forecasting): change forecasting endpoint prefix

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1204,7 +1204,7 @@ paths:
         401:
           $ref: '#/components/responses/UnauthorizedError'
 
-  /toptimize/v1/forecasting/marketplace:
+  /public/v1/toptimize/forecasting/marketplace:
     get:
       tags:
         - Toptimize
@@ -1327,7 +1327,7 @@ paths:
         401:
           $ref: '#/components/responses/UnauthorizedError'
 
-  /toptimize/v1/forecasting/inventory:
+  /public/v1/toptimize/forecasting/inventory:
     post:
       tags:
         - Toptimize
@@ -1559,7 +1559,7 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         404:
           description: Marketplace is not available for forecasting (e.g., not enough data)
-  /toptimize/v1/forecasting/campaign:
+  /public/v1/toptimize/forecasting/campaign:
     post:
       tags:
         - Toptimize


### PR DESCRIPTION
# Main changes

* Change the prefix of the forecasting endpoints from `/toptimize/v1` to `/public/v1/toptimize`

This change was required because of issues in the deployment of the public endpoint.