### PR TITLE
feat: update v2 sponsored brands

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1396,6 +1396,7 @@ components:
         Exactly **one** of the following fields must be set:
           * `products`
           * `category`
+          * `searchQuery`
       required:
         - winners
         - placementId
@@ -1453,8 +1454,28 @@ components:
               triggers:
                 products:
                   ids:
-                    - "1"
-                    - "8"
+                    - "vanilla_yogurt"
+                    - "nonfat_vanilla_yogurt"
+              geoTargeting: New York
+              opaqueUserId": user-123
+        Example 2:
+          auctions:
+            - winners: 2
+              placementId: some-placement
+              triggers:
+                category:
+                  id: c_yogurt
+              geoTargeting: New York
+              opaqueUserId": user-123
+        Example 3:
+          auctions:
+            - winners: 2
+              placementId: some-placement
+              triggers:
+                searchQuery:
+                  id: vanilla yogurt
+              geoTargeting: New York
+              opaqueUserId": user-123
     SponsoredBrandAuctionResult:
       type: object
       properties:
@@ -1479,40 +1500,26 @@ components:
             - winners:
                 - rank: 1
                   resolvedBidId: ChAGc-G66Wt7LKQEOcW8VBdIEhABjz_zDXx7db-ZYpxiwJ3DGhABjr4Lt_J0_a7Xv_uIfyOXIgUKATEQATDrrg8
-                  productId: "1"
+                  type: "url"
+                  id: "https://some.url.com/myyougurtbrand/page"
                   title: Brand Example Promo 1
-                  assets:
-                    - url: https://assets.hosted.topsort.com/5bcccb92e5eaaa73ce9fcc545e944865bf70e9b60e5a048979769282450343c4/example-banner-1.png
-                      role: image
-                      contentType: image/png
-                      contentLength: 33902
-                      width: 920
-                      height: 920
-                    - url: https://assets.hosted.topsort.com/c27c9cd94badc90fb50827e144dfacb2f51a601560905b950f525cec725ea85f/example-logo-1.png
-                      role: logo
-                      contentType: image/png
-                      contentLength: 80648
-                      width: 264
-                      height: 264
-                  campaignId: 018f3ff3-0d7c-7b75-bf99-629c62c09dc3
+                  content:
+                    headline: "some cool regular yogurt headline",
+                    brandName: "my regular yogurt brand",
+                    creative1: "https://some.url.com/regular_yogurt.jpeg"
+                  campaignId: 01934a6e-7bb3-79c1-89b3-134e2e3bf88e
+                  productIds: ["vanilla_yogurt", "strawberry_yogurt"]
                 - rank: 2
                   resolvedBidId: ChAGc-G66Wt7LKQEOcW8VBdIEhABk0pue7N5wYmzE04uO_iOGhABjr4Lt_J0_a7Xv_uIfyOXIgUKATgQATDrrg8
-                  productId: "8"
+                  type: "url"
+                  id: "https://some.url.com/mynonfatyougurtbrand/page"
                   title: Brand Example Promo 2
-                  assets:
-                    - url: https://assets.hosted.topsort.com/c049a46d834ab071cdde63e401d4efcd554e1a124f05c4ba9b3743fed2d43c4b/example-banner-2.jpeg
-                      role: image
-                      contentType: image/jpeg
-                      contentLength: 4505
-                      width: 403
-                      height: 125
-                    - url: https://assets.hosted.topsort.com/db41a8b8b22c5ed9091f9f154b552b6bc1d1dbeb85059190f1c3b202977938f1/example-logo-2.png
-                      role: logo
-                      contentType: image/png
-                      contentLength: 34747
-                      width: 140
-                      height: 160
+                  content:
+                    headline: "some cool nonfat regular yogurt headline",
+                    brandName: "my nonfat yogurt brand",
+                    creative1: "https://some.url.com/nonfat_yogurt.jpeg"
                   campaignId: 01934a6e-7bb3-79c1-89b3-134e2e3bf88e
+                  productIds: ["nonfat_vanilla_yogurt", "nonfat_strawberry_yogurt"]
               error: false
     SponsoredBrandWinner:
       type: object

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1059,6 +1059,14 @@ components:
           description: The ID of the campaign that won the auction.
           examples:
             - 4bcc6093-f367-4df2-aa1b-7c1674dd6441
+    PlacementContent:
+      type: object
+      additionalProperties: true
+      description: >
+        A flexible JSON object with key-value pairs that map to the asset's filled content template.
+        The template can be customized by the marketplace. Note: When the content field is part of
+        the  response, the url links to an asset with the same JSON object available on the content
+        object.
     BannersWinner:
       type: object
       required:
@@ -1506,6 +1514,19 @@ components:
             The marketplace's ID of the winning entity, depending on the target of the campaign.
           examples:
             - p_Mfk15
+        type:
+          type: string
+          description: The target type of the winning bid.
+          enum:
+            - product
+            - url
+        id:
+          type: string
+          description:
+            The marketplace's ID of the winning entity, depending on the target of the campaign.
+          examples:
+            - p_Mfk15
+            - https://some.url.com/topsort-brand
         resolvedBidId:
           $ref: "#/components/schemas/ResolvedBidID"
         title:
@@ -1523,6 +1544,18 @@ components:
           items:
             $ref: "#/components/schemas/SponsoredBrandAsset"
           minItems: 1
+        productIds:
+          description: List of product IDs associated with the sponsored brand winning campaign.
+          type: array
+          examples:
+            - ["product123", "product456"]
+        content:
+          $ref: "#/components/schemas/PlacementContent"
+          example:
+            headline: "Topsort Rocks"
+            brandName: "Topsort Brand"
+            creative: "https://some.url.com/rocks.jpeg"
+
     SponsoredBrandAsset:
       type: object
       properties:

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -719,7 +719,7 @@ components:
         location:
           description: The location this auction is being run for.
           type: string
-          examples: 
+          examples:
             - New York
     SearchQuery:
       type: string
@@ -1436,7 +1436,7 @@ components:
           type: string
           x-stoplight:
             id: biqordtdbp58t
-          examples: 
+          examples:
             - "some-placement-id"
         triggers:
           type: object
@@ -1476,30 +1476,30 @@ components:
           $ref: "#/components/schemas/Page"
       examples:
         - auctions:
-          - winners: 2
-            placementId: some-placement
-            triggers:
-              products:
-                ids:
-                  - "vanilla_yogurt"
-                  - "nonfat_vanilla_yogurt"
-            geoTargeting: New York
-            opaqueUserId": user-123
+            - winners: 2
+              placementId: some-placement
+              triggers:
+                products:
+                  ids:
+                    - "vanilla_yogurt"
+                    - "nonfat_vanilla_yogurt"
+              geoTargeting: New York
+              opaqueUserId": user-123
         - auctions:
-          - winners: 2
-            placementId: some-placement
-            triggers:
-              category:
-                id: c_yogurt
-            geoTargeting: New York
-            opaqueUserId": user-123
+            - winners: 2
+              placementId: some-placement
+              triggers:
+                category:
+                  id: c_yogurt
+              geoTargeting: New York
+              opaqueUserId": user-123
         - auctions:
-          - winners: 2
-            placementId: some-placement
-            triggers:
-              searchQuery: vanilla yogurt
-            geoTargeting: New York
-            opaqueUserId": user-123
+            - winners: 2
+              placementId: some-placement
+              triggers:
+                searchQuery: vanilla yogurt
+              geoTargeting: New York
+              opaqueUserId": user-123
     SponsoredBrandAuctionResult:
       type: object
       properties:

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -712,6 +712,8 @@ components:
         location:
           description: The location this auction is being run for.
           type: string
+          example:
+            New York
     SearchQuery:
       type: string
       description: The search string provided by a user.
@@ -1059,7 +1061,7 @@ components:
           description: The ID of the campaign that won the auction.
           examples:
             - 4bcc6093-f367-4df2-aa1b-7c1674dd6441
-    PlacementContent:
+    SponsoredBrandContent:
       type: object
       additionalProperties: true
       description: >
@@ -1067,6 +1069,10 @@ components:
         The template can be customized by the marketplace. Note: When the content field is part of
         the  response, the url links to an asset with the same JSON object available on the content
         object.
+      example:
+        headline: "Topsort Rocks"
+        brandName: "Topsort Brand"
+        creative: "https://some.url.com/rocks.jpeg"
     BannersWinner:
       type: object
       required:
@@ -1404,6 +1410,7 @@ components:
           type: string
           x-stoplight:
             id: biqordtdbp58t
+          example: "some-placement-id"
         triggers:
           type: object
           description: >
@@ -1412,13 +1419,28 @@ components:
             query.
           x-stoplight:
             id: ne5n2vzri6o92
-          properties:
-            category:
-              $ref: "#/components/schemas/SingleCategory"
-            products:
-              $ref: "#/components/schemas/Products"
-            searchQuery:
-              $ref: "#/components/schemas/SearchQuery"
+          oneOf:
+            - type: object
+              properties:
+                category:
+                  $ref: "#/components/schemas/SingleCategory"
+              required:
+                - category
+              description: A trigger based on a product category.
+            - type: object
+              properties:
+                products:
+                  $ref: "#/components/schemas/Products"
+              required:
+                - products
+              description: A trigger based on a set of specific products.
+            - type: object
+              properties:
+                searchQuery:
+                  $ref: "#/components/schemas/SearchQuery"
+              required:
+                - searchQuery
+              description: A trigger based on a search query.
         opaqueUserId:
           $ref: "#/components/schemas/OpaqueUserID"
         geoTargeting:
@@ -1538,11 +1560,7 @@ components:
           examples:
             - ["product123", "product456"]
         content:
-          $ref: "#/components/schemas/PlacementContent"
-          example:
-            headline: "Topsort Rocks"
-            brandName: "Topsort Brand"
-            creative: "https://some.url.com/rocks.jpeg"
+          $ref: "#/components/schemas/SponsoredBrandContent"
     TravelAuctionRequest:
       description: Describes the intent of running a single auction.
       oneOf:

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1524,9 +1524,10 @@ components:
       type: object
       required:
         - rank
-        - productId
+        - type
+        - id
         - resolvedBidId
-        - assets
+        - content
       properties:
         rank:
           type: integer

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -712,6 +712,9 @@ components:
         location:
           description: The location this auction is being run for.
           type: string
+    SearchQuery:
+      type: string
+      description: The search string provided by a user.
     ResolvedBidID:
       type: string
       description: An opaque Topsort ID to be used when this item is interacted with.
@@ -739,8 +742,7 @@ components:
         category:
           $ref: "#/components/schemas/AuctionCategory"
         searchQuery:
-          type: string
-          description: The search string provided by a user.
+          $ref: "#/components/schemas/SearchQuery"
         products:
           $ref: "#/components/schemas/Products"
         geoTargeting:
@@ -785,8 +787,7 @@ components:
         category:
           $ref: "#/components/schemas/AuctionCategory"
         searchQuery:
-          type: string
-          description: The search string provided by a user.
+          $ref: "#/components/schemas/SearchQuery"
         device:
           $ref: "#/components/schemas/Device"
         geoTargeting:
@@ -1332,6 +1333,8 @@ components:
       required:
         - ids
       type: object
+      description: >
+        List of products for the purpose of running an auction.
       properties:
         ids:
           type: array
@@ -1395,6 +1398,10 @@ components:
             id: biqordtdbp58t
         triggers:
           type: object
+          description: >
+            Triggers provide the context for an ad auction. For Sponsored Brands, the trigger must
+            be one of the  following: a product category, a set of specific products, or a search
+            query.
           x-stoplight:
             id: ne5n2vzri6o92
           properties:
@@ -1402,8 +1409,12 @@ components:
               $ref: "#/components/schemas/SingleCategory"
             products:
               $ref: "#/components/schemas/Products"
+            searchQuery:
+              $ref: "#/components/schemas/SearchQuery"
         opaqueUserId:
           $ref: "#/components/schemas/OpaqueUserID"
+        geoTargeting:
+          $ref: "#/components/schemas/GeoTargeting"
       x-examples:
         Example 1:
           auctions:

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -712,8 +712,7 @@ components:
         location:
           description: The location this auction is being run for.
           type: string
-          example:
-            New York
+          example: New York
     SearchQuery:
       type: string
       description: The search string provided by a user.
@@ -1504,8 +1503,8 @@ components:
                   id: "https://some.url.com/myyougurtbrand/page"
                   title: Brand Example Promo 1
                   content:
-                    headline: "some cool regular yogurt headline",
-                    brandName: "my regular yogurt brand",
+                    headline: "some cool regular yogurt headline"
+                    brandName: "my regular yogurt brand"
                     creative1: "https://some.url.com/regular_yogurt.jpeg"
                   campaignId: 01934a6e-7bb3-79c1-89b3-134e2e3bf88e
                   productIds: ["vanilla_yogurt", "strawberry_yogurt"]
@@ -1515,9 +1514,9 @@ components:
                   id: "https://some.url.com/mynonfatyougurtbrand/page"
                   title: Brand Example Promo 2
                   content:
-                    headline: "some cool nonfat regular yogurt headline",
-                    brandName: "my nonfat yogurt brand",
-                    creative1: "https://some.url.com/nonfat_yogurt.jpeg"
+                    - headline: "some cool nonfat regular yogurt headline"
+                      brandName: "my nonfat yogurt brand"
+                      creative1: "https://some.url.com/nonfat_yogurt.jpeg"
                   campaignId: 01934a6e-7bb3-79c1-89b3-134e2e3bf88e
                   productIds: ["nonfat_vanilla_yogurt", "nonfat_strawberry_yogurt"]
               error: false

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1508,12 +1508,6 @@ components:
             the auction. In an auction response, the winners array is sorted so rank will match the
             entry's index.
           minimum: 1
-        productId:
-          type: string
-          description:
-            The marketplace's ID of the winning entity, depending on the target of the campaign.
-          examples:
-            - p_Mfk15
         type:
           type: string
           description: The target type of the winning bid.
@@ -1538,12 +1532,6 @@ components:
           description: The ID of the vendor associated with this sponsored brand winner.
           examples:
             - v_8fj2D
-        assets:
-          description: Assets used to render the sponsored brand ad.
-          type: array
-          items:
-            $ref: "#/components/schemas/SponsoredBrandAsset"
-          minItems: 1
         productIds:
           description: List of product IDs associated with the sponsored brand winning campaign.
           type: array
@@ -1555,34 +1543,6 @@ components:
             headline: "Topsort Rocks"
             brandName: "Topsort Brand"
             creative: "https://some.url.com/rocks.jpeg"
-
-    SponsoredBrandAsset:
-      type: object
-      properties:
-        url:
-          type: string
-          format: uri
-          description: >
-            A vendor provided asset that the marketplace has to render. The asset will be served by
-            Topsort's CDN.
-        role:
-          type: string
-          description: The role of the asset. It can be either `logo` or `image`.
-        contentType:
-          type: string
-          description: The asset MIME type.
-        contentLength:
-          type: integer
-          format: uint32
-          description: The size of the asset in bytes.
-        width:
-          type: integer
-          format: uint32
-          description: The asset width in pixels.
-        height:
-          type: integer
-          format: uint32
-          description: The asset height in pixels.
     TravelAuctionRequest:
       description: Describes the intent of running a single auction.
       oneOf:

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1065,9 +1065,7 @@ components:
       additionalProperties: true
       description: >
         A flexible JSON object with key-value pairs that map to the asset's filled content template.
-        The template can be customized by the marketplace. Note: When the content field is part of
-        the  response, the url links to an asset with the same JSON object available on the content
-        object.
+        The template can be customized by the marketplace.
       example:
         headline: "Topsort Rocks"
         brandName: "Topsort Brand"
@@ -1471,8 +1469,7 @@ components:
             - winners: 2
               placementId: some-placement
               triggers:
-                searchQuery:
-                  id: vanilla yogurt
+                searchQuery: vanilla yogurt
               geoTargeting: New York
               opaqueUserId": user-123
     SponsoredBrandAuctionResult:

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -719,7 +719,8 @@ components:
         location:
           description: The location this auction is being run for.
           type: string
-          example: New York
+          examples: 
+            - New York
     SearchQuery:
       type: string
       description: The search string provided by a user.
@@ -1077,10 +1078,10 @@ components:
       description: >
         A flexible JSON object with key-value pairs that map to the asset's filled content template.
         The template can be customized by the marketplace.
-      example:
-        headline: "Topsort Rocks"
-        brandName: "Topsort Brand"
-        creative: "https://some.url.com/rocks.jpeg"
+      examples:
+        - headline: "Topsort Rocks"
+          brandName: "Topsort Brand"
+          creative: "https://some.url.com/rocks.jpeg"
     BannersWinner:
       type: object
       required:
@@ -1358,12 +1359,12 @@ components:
             template. The template can be customized by the marketplace. Note: When the content
             field is part of the  response, the url links to an asset with the same JSON object
             available on the content object.
-          example:
-            headingText: "A banner for Topsort with a product image and a shop now button"
-            bannerText: "Topsort has the best tech!"
-            bannerTextColour: "48a94c"
-            heroImage: "https://assets.imageurl.io/s/85d2d333-eed5-44d7-b131-8851d59f0574"
-            heroImageAltText: "Topsort product image"
+          examples:
+            - headingText: "A banner for Topsort with a product image and a shop now button"
+              bannerText: "Topsort has the best tech!"
+              bannerTextColour: "48a94c"
+              heroImage: "https://assets.imageurl.io/s/85d2d333-eed5-44d7-b131-8851d59f0574"
+              heroImageAltText: "Topsort product image"
 
       required:
         - url
@@ -1435,7 +1436,8 @@ components:
           type: string
           x-stoplight:
             id: biqordtdbp58t
-          example: "some-placement-id"
+          examples: 
+            - "some-placement-id"
         triggers:
           type: object
           description: >
@@ -1472,35 +1474,32 @@ components:
           $ref: "#/components/schemas/GeoTargeting"
         page:
           $ref: "#/components/schemas/Page"
-      x-examples:
-        Example 1:
-          auctions:
-            - winners: 2
-              placementId: some-placement
-              triggers:
-                products:
-                  ids:
-                    - "vanilla_yogurt"
-                    - "nonfat_vanilla_yogurt"
-              geoTargeting: New York
-              opaqueUserId": user-123
-        Example 2:
-          auctions:
-            - winners: 2
-              placementId: some-placement
-              triggers:
-                category:
-                  id: c_yogurt
-              geoTargeting: New York
-              opaqueUserId": user-123
-        Example 3:
-          auctions:
-            - winners: 2
-              placementId: some-placement
-              triggers:
-                searchQuery: vanilla yogurt
-              geoTargeting: New York
-              opaqueUserId": user-123
+      examples:
+        - auctions:
+          - winners: 2
+            placementId: some-placement
+            triggers:
+              products:
+                ids:
+                  - "vanilla_yogurt"
+                  - "nonfat_vanilla_yogurt"
+            geoTargeting: New York
+            opaqueUserId": user-123
+        - auctions:
+          - winners: 2
+            placementId: some-placement
+            triggers:
+              category:
+                id: c_yogurt
+            geoTargeting: New York
+            opaqueUserId": user-123
+        - auctions:
+          - winners: 2
+            placementId: some-placement
+            triggers:
+              searchQuery: vanilla yogurt
+            geoTargeting: New York
+            opaqueUserId": user-123
     SponsoredBrandAuctionResult:
       type: object
       properties:


### PR DESCRIPTION
Updated sponsored brands documentation to match v2.

Tried `oneOf` in line 1420. Doesn't work in the editors render, but I wonder if it works in mintilfy. The idea is that we show three different scenarios for the three different triggers. This is to avoid showing all three and creating confusions (you can only use one at the time).