### PR TITLE
fix: events minintems

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1888,27 +1888,40 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Impression"
-          minItems: 1
+          minItems: 0
           maxItems: 50
         clicks:
           type: array
           items:
             $ref: "#/components/schemas/Click"
-          minItems: 1
+          minItems: 0
           maxItems: 50
         purchases:
           type: array
           items:
             $ref: "#/components/schemas/Purchase"
-          minItems: 1
+          minItems: 0
           maxItems: 50
         pageviews:
           type: array
           items:
             $ref: "#/components/schemas/Pageview"
-          minItems: 1
+          minItems: 0
           maxItems: 50
       minProperties: 1
+      anyOf:
+        - properties:
+            impressions:
+              minItems: 1
+        - properties:
+            clicks:
+              minItems: 1
+        - properties:
+            purchases:
+              minItems: 1
+        - properties:
+            pageviews:
+              minItems: 1
       examples:
         - impressions:
             - id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c


### PR DESCRIPTION
In reality our API can take empty arrays, but at least one of them must be non-empty