### PR TITLE
fix: update validation for `qualityScores` array in topsort-api-v2.yml

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1563,17 +1563,15 @@ components:
             with matching array index.
 
             If given, these values will be combined with our internal quality scores to provide a
-            score
-
-            that better represents the relevance of the participating products.
+            score that better represents the relevance of the participating products.
 
             Note that the length of this array must be the same as the length of the `ids` array and
-
-            that the values must be between 0 and 1.
+            that the values must be greater than 0 and less than or equal to 1.
           items:
             type: number
             maximum: 1
             exclusiveMinimum: 0
+            minimum: 0
             examples:
               - 0.75
             format: double


### PR DESCRIPTION
## Summary:
Our documentation for qualityScores array inside the products object in payload to engine's `/v2/auctions` endpoint is not fully aligned with the actual validation. The validation for qualityScores array enforce a non-zero constraint, but the description and range in the docs are not explicit in the fact that a `qualityScores` array with item(s) as zero will be rejected.
<img width="1512" height="867" alt="image" src="https://github.com/user-attachments/assets/bd8a7cd1-99f9-49cb-8168-28a9b8d1c278" />

Additionally, Mintlify seems to have trouble with rendering the correct range  from OpenAPI specs 3.1.0's `exclusiveMinimum` parameter. To correctly render the range to be exclusive of 0,  an additional `minimum` parameter of 0 need to be added, hence the duplicate minimums in the yml file. This can be removed from once Mintlify fully support the exclusiveMinimum parameter.

## Key Changes:
For `topsort-api-v2.yml`:
- Refactored description to explicitly describe the non-zero constraint and add better line break support
- Added a minimum parameter to help range fully reflect the exclusion of 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates OpenAPI spec to align docs with validation for `products.qualityScores`.
> 
> - Clarifies description to state values must be greater than 0 and less than or equal to 1
> - Adds `minimum: 0` while keeping `exclusiveMinimum: 0` to aid rendering; retains `maximum: 1`
> - Cleans up line breaks/formatting in the `qualityScores` description
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daac00518dcd03312fcb5f8461182f29f601d0f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->