### PR TITLE
feat: add marketplaceExperimentVariant to sponsored listings auction

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1779,7 +1779,6 @@ components:
             type: number
             maximum: 1
             exclusiveMinimum: 0
-            minimum: 0
             examples:
               - 0.75
             format: double

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1024,6 +1024,17 @@ components:
           $ref: "#/components/schemas/Page"
         filter:
           $ref: "#/components/schemas/AttributesFilter"
+        marketplaceExperimentVariant:
+          type: string
+          maxLength: 10
+          description: >
+            Optional. A marketplace-defined experiment variant tag (maximum 10 characters). By
+            default Topsort does not change auction behavior based on this value; it is recorded
+            alongside the auction so you can run your own A/B experiments and then slice the
+            resulting ad metrics (impressions, clicks, purchases) by variant. Contact your Topsort
+            representative if you want this value to influence auction behavior.
+          examples:
+            - exp_a
         demandSources:
           type: array
           items:


### PR DESCRIPTION
## Summary

- Documents the optional `marketplaceExperimentVariant` field (`type: string`, `maxLength: 10`) on the **Sponsored Listings** auction request (`SponsoredListingsAuction`) for `POST /v2/auctions`. The Auction Engine already accepts, validates (max 10 chars) and records this field in auction reporting (`resolved_auction_bids` and `auction_report`); it was simply undocumented in the public spec.
- Added with a disclaimer: by default it does not change auction behavior — it is recorded so clients can run their own A/B experiments and slice ad metrics (impressions, clicks, purchases) by variant.
- Scoped to **Sponsored Listings only** (not banners), as requested.
- Drops a redundant `minimum: 0` on `Products.qualityScores.items` (keeps `exclusiveMinimum: 0`) so the `recommended-strict` redocly rule `no-mixed-number-range-constraints` passes. `exclusiveMinimum: 0` already encodes the "greater than 0" constraint and matches the existing `QualityScore` component and `price` field conventions.

## Test Plan

- [x] `redocly lint --extends recommended-strict topsort-api-v2.yml` — valid, 0 errors
- [x] `prettier --check .` — passes
- [x] `yamllint topsort-api-v2.yml` — passes
- [x] `typos` — passes