### PR TITLE
feat: add render event to /v2/events

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -422,7 +422,7 @@ paths:
       description: >
         Use the `/events` endpoint to report user interactions and activity in on a marketplace:
 
-        - **Renders** — an ad was placed in the DOM.
+        - **Renders** — an ad was rendered in the page.
 
         - **Impressions** — a user viewed an asset.
 
@@ -2415,8 +2415,8 @@ components:
       title: Render
       type: object
       description: >
-        A render means an ad was placed in the DOM (IAB "rendered"). Renders are for sponsored ads
-        only, so `resolvedBidId` is required.
+        A render means an ad was inserted into the page (IAB "rendered"). Renders are for sponsored
+        ads only, so `resolvedBidId` is required.
       required:
         - resolvedBidId
         - occurredAt

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1770,7 +1770,6 @@ components:
             type: number
             maximum: 1
             exclusiveMinimum: 0
-            minimum: 0
             examples:
               - 0.75
             format: double
@@ -2416,8 +2415,8 @@ components:
       title: Render
       type: object
       description: >
-        A render means an ad was placed in the DOM (IAB "rendered"), regardless of whether it
-        became viewable. Renders are for sponsored ads only, so `resolvedBidId` is required.
+        A render means an ad was placed in the DOM (IAB "rendered"). Renders are for sponsored ads
+        only, so `resolvedBidId` is required.
       required:
         - resolvedBidId
         - occurredAt

--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -422,6 +422,8 @@ paths:
       description: >
         Use the `/events` endpoint to report user interactions and activity in on a marketplace:
 
+        - **Renders** — an ad was placed in the DOM.
+
         - **Impressions** — a user viewed an asset.
 
         - **Clicks** — a user clicked on an asset.
@@ -450,7 +452,7 @@ paths:
         Room](https://docs.topsort.com/knowledge-base/analytics/data-room/).
       operationId: reportEvents
       requestBody:
-        description: Event data including impressions, clicks, purchases, and page views.
+        description: Event data including renders, impressions, clicks, purchases, and page views.
         content:
           application/json:
             schema:
@@ -2295,6 +2297,14 @@ components:
       additionalProperties: false
       minProperties: 1
       properties:
+        renders:
+          title: Renders
+          description: An array of render events
+          type: array
+          minItems: 0
+          maxItems: 50
+          items:
+            $ref: "#/components/schemas/Render"
         impressions:
           title: Impressions
           description: An array of impression events
@@ -2328,6 +2338,20 @@ components:
           items:
             $ref: "#/components/schemas/PageView"
       examples:
+        - renders:
+            - id: 3f2b9c14-7a1d-4e2b-9c3a-1b2c3d4e5f60
+              occurredAt: "2019-01-01T12:59:58-05:00"
+              opaqueUserId: 71303ce0-de89-496d-8270-6434589615e8
+              resolvedBidId: WyJiX01mazE1IiwiMTJhNTU4MjgtOGVhZC00Mjk5LTgzMjctY2ViYjAwMmEwZmE4IiwibGlzdGluZ3MiLCJkZWZhdWx0IiwiIl0=
+              placement:
+                path: /categories/dairy
+                position: 1
+                page: 1
+                pageSize: 15
+                categoryIds:
+                  - 9BLIe
+              deviceType: mobile
+              channel: onsite
         - impressions:
             - id: eb874c98-bf4d-40a9-ae6d-fcf4cecb535c
               occurredAt: "2019-01-01T12:59:59-05:00"
@@ -2388,6 +2412,44 @@ components:
                 value: dairy
               deviceType: mobile
               channel: onsite
+    Render:
+      title: Render
+      type: object
+      description: >
+        A render means an ad was placed in the DOM (IAB "rendered"), regardless of whether it
+        became viewable. Renders are for sponsored ads only, so `resolvedBidId` is required.
+      required:
+        - resolvedBidId
+        - occurredAt
+        - opaqueUserId
+        - id
+      additionalProperties: false
+      properties:
+        resolvedBidId:
+          $ref: "#/components/schemas/ResolvedBidID"
+          description: >
+            The `resolvedBidId` received from the `/v2/auctions` response.
+        placement:
+          $ref: "#/components/schemas/Placement"
+        occurredAt:
+          $ref: "#/components/schemas/occurredAt"
+        opaqueUserId:
+          $ref: "#/components/schemas/OpaqueUserID"
+        id:
+          $ref: "#/components/schemas/EventIdentifier"
+        page:
+          $ref: "#/components/schemas/Page"
+        deviceType:
+          $ref: "#/components/schemas/DeviceType"
+        channel:
+          type: string
+          description: Optional. The channel where the event occurred.
+          enum:
+            - onsite
+            - offsite
+            - instore
+          examples:
+            - onsite
     Impression:
       title: Impression
       type: object


### PR DESCRIPTION
## Summary
Documents the new `rendered` event in the public Events API (`/v2/events`), so clients can report renders alongside impressions, clicks and purchases. A render is an ad placed in the DOM (IAB "rendered").

## Changes (`topsort-api-v2.yml`)

- `/v2/events`: add a **Renders** bullet and update the request-body description.
- `EventsRequest`: add a `renders` array (`maxItems: 50`).
- New `Render` schema: `resolvedBidId` / `occurredAt` / `opaqueUserId` / `id` required; `placement` / `page` / `deviceType` / `channel` optional. Sponsored-only, non-chargeable and non-attributable.
- Add a render request example; order render before impression (funnel: rendered → viewable).

### Note: unrelated strict-lint fix
This PR also removes a redundant `minimum: 0` from the `qualityScores` items schema (used in `/v2/auctions`), keeping `exclusiveMinimum: 0`, which matches its own description ("values must be greater than 0"). This is **not related to the render event**: it is a pre-existing `no-mixed-number-range-constraints` violation on `main` that the `recommended-strict` Redocly check flags across the whole spec, so it blocks any PR touching this file. Fixed here only to unblock.

## Validation
- Matches the auction-engine v2 contract — request field `renders` (`binding:"max=50"`), `Render` fields/required flags per `behavior-data-service/bdssrv/v2/model_render.go`, and `channel` / `deviceType` enums per `ts.Channel` / `ts.DeviceType`.
- `redocly lint` passes (only the pre-existing, unrelated warning); `yamllint` clean.