### PR TITLE
Document device field on sponsored listings auction

### DIFF
--- a/topsort-api-v2.yml
+++ b/topsort-api-v2.yml
@@ -1016,6 +1016,8 @@ components:
           $ref: "#/components/schemas/SearchQuery"
         products:
           $ref: "#/components/schemas/Products"
+        device:
+          $ref: "#/components/schemas/Device"
         geoTargeting:
           $ref: "#/components/schemas/GeoTargeting"
         opaqueUserId:


### PR DESCRIPTION
## What
`device` was only documented on `BannersAuction`, but the `/v2/auctions` handler parses it for **every** auction type in the batch — it unmarshals all requests into one shared struct and handles device with no gating on `type` ([`api_auctions.go:250-260`](https://github.com/Topsort/auction-engine/blob/main/internal/api/auctions/v2/api_auctions.go#L250-L260)): validates against `desktop|mobile`, rejects anything else with `InvalidDevice`, and defaults empty to `ts.DeviceDefault` (`desktop`), matching the existing `default: desktop` on the `Device` schema.

So listings callers can already send `device` and have it honored — the spec just didn't say so. This adds the existing `Device` `$ref` to `SponsoredListingsAuction`, positioned before `geoTargeting` to mirror `BannersAuction`. Optional, no new schema, no behavior change.

**Not included: sponsored brand.** `/v2/auctions/sponsored-brand` is a separate handler and `SingleSponsoredBrandAuctionRequest` has no `Device` field at all, so documenting it there would advertise a field the engine silently drops. That needs engine work first — happy to file an issue if useful.

## How to test
Spec-only change. Verified locally against every check in `.github/workflows/lint-tools.yml`:

- `prettier --check` — clean
- `redocly lint --extends recommended-strict` — valid
- `yamllint` — clean
- `typos` — clean
- `vacuum lint -d -e -b` — 95/100 [A], 0 errors; byte-identical to the `main` baseline (8 warnings / 23 informs before and after)